### PR TITLE
Fix search path for relative directories Fixes #1

### DIFF
--- a/lib/search-instance.js
+++ b/lib/search-instance.js
@@ -68,7 +68,7 @@ class SearchInstance {
                 );
             } else {
                 foundPaths = foundPaths.concat(projectPaths
-                    .map(pp => pp + '*' + searchPath)
+                    .map(pp => path.join(pp, searchPath))
                 );
             }
         });


### PR DESCRIPTION
No longer resolve relative path to `project/path/root*relative/path`... resolve it to `project/path/root/relative/path` instead.